### PR TITLE
Fix resizing on Retina display

### DIFF
--- a/src/OpenGP/GL/GlfwWindow.h
+++ b/src/OpenGP/GL/GlfwWindow.h
@@ -30,9 +30,6 @@ public:
 public:
     ~GlfwWindow(){ active_windows()->erase(_window); }
     GlfwWindow(const std::string& title, int width, int height){
-        this->_width = width;
-        this->_height = height;
-
         {
             if( !glfwInit() )
                 mFatal() << "Failed to initialize GLFW";
@@ -51,7 +48,7 @@ public:
             
             /// Attempt to open the window: fails if required version unavailable
             /// @note Intel GPUs do not support OpenGL 3.0
-            if( !(_window = glfwCreateWindow(_width, _height, title.c_str(), nullptr, nullptr)) )
+            if( !(_window = glfwCreateWindow(width, height, title.c_str(), nullptr, nullptr)) )
                 mFatal() << "Failed to open OpenGL 3 GLFW window.";
             
             /// Outputs the OpenGL version
@@ -81,7 +78,7 @@ public:
             glfwSetKeyCallback(_window, glfw_key_callback);
             glfwSetMouseButtonCallback(_window, glfw_mouse_press_callback);
             glfwSetCursorPosCallback(_window, glfw_mouse_move_callback);
-            glfwSetWindowSizeCallback(_window, glfw_window_size_callback);
+            glfwSetFramebufferSizeCallback(_window, glfw_framebuffer_size_callback);
             glfwSetScrollCallback(_window, glfw_scroll_callback);
 
         }
@@ -125,7 +122,7 @@ public:
     virtual void mouse_press_callback(int /*button*/, int /*action*/, int /*mods*/) {}
     virtual void mouse_move_callback(double /*xPos*/, double /*yPos*/) {}
     virtual void scroll_callback(double /*xOffset*/, double /*yOffset*/) {}    
-    virtual void window_size_callback(int width, int height){
+    virtual void framebuffer_size_callback(int width, int height){
         _width = width;
         _height = height;
         scene.screen_resize(_width, _height);
@@ -153,8 +150,8 @@ private:
         active_windows()->at(window)->mouse_move_callback(xPos, yPos);
     }
 
-    static void glfw_window_size_callback(GLFWwindow* window, int width, int height) {
-        active_windows()->at(window)->window_size_callback(width, height);
+    static void glfw_framebuffer_size_callback(GLFWwindow* window, int width, int height) {
+        active_windows()->at(window)->framebuffer_size_callback(width, height);
     }
 
     static void glfw_scroll_callback(GLFWwindow* window, double xOffset, double yOffset) {


### PR DESCRIPTION
On Retina displays, screen coordinates are not equivalent to pixels. Since OpenGL works with pixels, we must use the framebuffer size (measured in pixels) - not the window size (measured in screen coordinates) - to update the scene when resizing.

Are we concerned with keeping the `_width` and `_height` properties consistent with the window size or framebuffer size?