### PR TITLE
simplify opposite_halfedge

### DIFF
--- a/examples/surface_mesh_barycenter.cpp
+++ b/examples/surface_mesh_barycenter.cpp
@@ -1,10 +1,13 @@
 #include <OpenGP/SurfaceMesh/SurfaceMesh.h>
+#include <OpenGP/MLogger.h>
 using namespace OpenGP;
 
-int main(int /*argc*/, char** argv) {
+int main(int argc, char** argv) {
+    std::string file = (argc>1) ? argv[1] : "bunny.obj";
+    
     SurfaceMesh mesh;
-
-    mesh.read(argv[1]);
+    bool success = mesh.read(file);
+    CHECK(success);
 
     // get (pre-defined) property storing vertex positions
     SurfaceMesh::Vertex_property<Vec3> points = mesh.get_vertex_property<Vec3>("v:point");

--- a/examples/surface_mesh_iterators.cpp
+++ b/examples/surface_mesh_iterators.cpp
@@ -1,10 +1,13 @@
 #include <OpenGP/SurfaceMesh/SurfaceMesh.h>
+#include <OpenGP/MLogger.h>
 using namespace OpenGP;
 
-int main(int /*argc*/, char** argv) {
-    SurfaceMesh mesh;
+int main(int argc, char** argv) {
+    std::string file = (argc>1) ? argv[1] : "bunny.obj";
 
-    mesh.read(argv[1]);
+    SurfaceMesh mesh;
+    bool success = mesh.read(file);
+    CHECK(success);
 
     float mean_valence = 0.0f;
     unsigned int vertex_valence;

--- a/src/OpenGP/SurfaceMesh/SurfaceMesh.h
+++ b/src/OpenGP/SurfaceMesh/SurfaceMesh.h
@@ -1109,7 +1109,7 @@ public: //---------------------------------------------- low-level connectivity
     /// returns the opposite halfedge of \c h
     Halfedge opposite_halfedge(Halfedge h) const
     {
-        return Halfedge((h.idx() & 1) ? h.idx()-1 : h.idx()+1);
+        return Halfedge(h.idx() ^ 1);
     }
 
     /// returns the halfedge that is rotated counter-clockwise around the


### PR DESCRIPTION
sanity check examples to show this works:
`1111 ^ 0001 = 1110`
`1110 ^ 0001 = 1111`
`0001 ^ 0001 = 0000`
`0000 ^ 0001 = 0001`